### PR TITLE
Switch to single table schema

### DIFF
--- a/PD-2022-05-25.md
+++ b/PD-2022-05-25.md
@@ -1,0 +1,194 @@
+# Remix, the details!
+
+My PD today was a bit of a deeper dive into [remix](https://remix.run).
+
+This effort was based on the [grunge stack]
+(https://github.com/remix-run/grunge-stack), which is a reference stack for
+deploying to AWS with DynamoDB and Lambda.
+
+I'm not sure how much of this is specific to remix, and how much is the grunge
+stack specifically.
+
+Prior to this PD session, I'd already launched the stack and gotten it
+working, but I'd like to do a bit of a dive into how it works, and list the
+details here.
+
+I'll also outline the nice bits, and the not-so-nice bits, as I see them.
+
+# Things I read about
+
+## Philosophy
+
+_see https://remix.run/docs/en/v1/pages/philosophy_
+
+### Server/Client model
+
+> You can make your server fast, but you can't control the user's network.
+> 
+> The only thing you can do is decrease the amount of stuff you send over the
+> network. Less JavaScript, less JSON, less CSS. This is easiest when you have
+> a server that you can move the logic to, and a framework that favors
+> progressive enhancement.
+
+### Web Standards, HTTP, and HTML
+
+> Browsers and HTML got really good in the 20+ years we've been using it.
+
+> We try to keep the Remix API to a minimum, and instead work with web
+> standards.
+
+> If the browser has an API for a use case, Remix uses it.
+
+### Progressive Enhancement
+
+Remix has APIs to both read and write data. It uses the `<form>` API, which
+means it works with or without client-side javascript. When javascript is
+available, it is used to improve transitions.
+
+The goal isn't to make the app work without javascript, it's more about
+simplifying the client/server model.
+
+### Don't Over Abstract
+
+> Remix's APIs make it convenient to use the fundamental
+> Browser/HTTP/JavaScript, but those technologies are not hidden from you.
+
+## Technical Details
+
+* Remix doesn't build a server, it builds a handler which is passed to a
+  server (such as Lambda, Cloudflare Workers, etc)
+* It's built on Web Fetch API, allowing it to run in both nodejs and
+  non-nodejs environments
+* Its compiler, `remix build` produces the HTTP handler, a browser build, and
+  an asset manifest. It is based on `esbuild`
+* Remix is the View and the Controller, but it leaves the Model up to you.
+  Remix Route modules take on both responsibilities. In the grunge stack, the
+  Model is built using `arc.tables`.
+* You can use Remix as just a server-side framework, with no client-side
+  javascript at all
+
+
+## Deployment
+
+🚀 Deployment is done using github actions! I simply cannot overstate how
+awesome this is.
+
+Some manual setup is needed (generate and store secrets), but this is easily
+performed using `arc`.
+
+# `arc` and `arc.tables`
+
+😎 `arc` seems to be both a deployment tool and a framework.
+
+In the grunge stack, it performs the following functions:
+* provisions the DynamoDB tables
+* provides easy access to the tables from server-side code
+* it also deploys some other things (lambdas, api gateways, etc)
+
+Notably, `arc` does NOT do the full infrustructure! The following are omitted:
+* DNS records
+* CloudFront/CDN &mdash; at least not in the grunge stack (this is probably
+  included in other reference stacks)
+* TLS certs
+
+However, these can all be done with other IaC tooling such as pulumi, so I
+don't really see this as much of a problem.
+
+`arc.tables` is the framework used to access the database.
+
+```ts
+import arc from "@architect/functions";
+
+const db = await arc.tables();
+const result = await await db.note.get({ pk: userId, sk: `note#${id}` });
+```
+
+Nifty!
+
+# Things I played with
+
+## Convert to single-table schema
+
+https://github.com/bennettp123/my-remix-app/pull/5
+
+Originally, the data model consisted of three types, each with its own
+dedicated DynamoDB table:
+* User
+    ```ts
+    pk: `email#${string}`
+    email: string
+    ```
+    | pk                     | sk | attributes              |
+    |------------------------|----|-------------------------|
+    | email#bob@example.com |    | email: bob@example.com |
+* Password
+    ```ts
+    pk: `email#${string}`
+    password: bcrypt(string)
+    ```
+    | pk                    | sk | attributes             |
+    |-----------------------|----|------------------------|
+    | email#bob@example.com |    | password: 09u32i1u.... |
+* Note
+    ```ts
+    pk: `email#${string}`
+    sk: `note#${cuid}`
+    title: string
+    body: string
+    ```
+    | pk                    | sk              | attributes                         |
+    |-----------------------|-----------------|------------------------------------|
+    | email#bob@example.com | note#iuohk... | title: my first note<br/>body: ... |
+    |                       | note#ldjad... | title: my 2nd note<br/>body: ...   |
+
+Access was generally just an easy lookup on `pk = :pk` in the relevent table.
+
+I decided to convert this to a single-table schema because [_reasons_]
+(https://www.alexdebrie.com/posts/dynamodb-single-table/#the-solution-pre-join-your-data-into-item-collections)
+&mdash; though this app doesn't really benefit from a single-table schema. The
+main reason was to dive into the existing models and get a better
+understanfing of both the reference stack and `arc.tables` itself.
+
+This turned out to be pretty easy: it's non-production &mdash; no need to
+worry about data loss 💀
+
+Also, the schema already included things like `email#` in its keys, so I
+didn't to make too many changes to the queries.
+
+Afterwards:
+
+* User
+    ```ts
+    pk: `email#${string}`
+    sk: 'email'
+    email: string
+    ```
+* Password
+    ```ts
+    pk: `email#${string}`
+    sk: 'password'
+    password: bcrypt(string)
+    ```
+* Note
+    ```ts
+    pk: `email#${string}`
+    sk: `note#${cuid}`
+    title: string
+    body: string
+    ```
+
+| pk                    | sk            | attributes                         |
+|-----------------------|---------------|------------------------------------|
+| email#bob@example.com | email         | email: bob@example.com             |
+|                       | password      | password: 09u32i1u....             |
+|                       | note#iuohk... | title: my first note<br/>body: ... |
+|                       | note#ldjad... | title: my 2nd note<br/>body: ...   |
+
+The only real addition was the sort key (`'email' | 'password`) to User and
+Password types.
+
+Once these were added, I removed the three different tables and stored all
+records in a single table.
+
+I updated the queries to include the sort key (`pk = :pk and sk = :sk`, or for
+notes, `pk = :pk and begins_with(sk, :sk)`).

--- a/app.arc
+++ b/app.arc
@@ -12,12 +12,6 @@ region ap-southeast-2
 @static
 
 @tables
-user
+app
   pk *String
-
-password
-  pk *String # userId
-
-note
-  pk *String  # userId
-  sk **String # noteId
+  sk **String

--- a/app/models/note.server.ts
+++ b/app/models/note.server.ts
@@ -24,7 +24,7 @@ export async function getNote({
 }: Pick<Note, "id" | "userId">): Promise<Note | null> {
   const db = await arc.tables();
 
-  const result = await await db.note.get({ pk: userId, sk: idToSk(id) });
+  const result = await await db.app.get({ pk: userId, sk: idToSk(id) });
 
   if (result) {
     return {
@@ -42,9 +42,12 @@ export async function getNoteListItems({
 }: Pick<Note, "userId">): Promise<Array<Pick<Note, "id" | "title">>> {
   const db = await arc.tables();
 
-  const result = await db.note.query({
-    KeyConditionExpression: "pk = :pk",
-    ExpressionAttributeValues: { ":pk": userId },
+  const result = await db.app.query({
+    KeyConditionExpression: "pk = :pk and begins_with(sk, :sk)",
+    ExpressionAttributeValues: {
+      ":pk": userId,
+      ":sk": 'note#',
+    },
   });
 
   return result.Items.map((n: any) => ({
@@ -60,7 +63,7 @@ export async function createNote({
 }: Pick<Note, "body" | "title" | "userId">): Promise<Note> {
   const db = await arc.tables();
 
-  const result = await db.note.put({
+  const result = await db.app.put({
     pk: userId,
     sk: `note#${cuid()}`,
     title: title,
@@ -76,5 +79,5 @@ export async function createNote({
 
 export async function deleteNote({ id, userId }: Pick<Note, "id" | "userId">) {
   const db = await arc.tables();
-  return db.note.delete({ pk: userId, sk: idToSk(id) });
+  return db.app.delete({ pk: userId, sk: idToSk(id) });
 }


### PR DESCRIPTION
Update the schema to use a single table, instead of multiple tables.

Currently, the data model consists of three types, each with its own
dedicated DynamoDB table:
* User
    ```ts
    pk: `email#${string}`
    email: string
    ```
    | pk                     | sk | attributes              |
    |------------------------|----|-------------------------|
    | email#bob@example.com |    | email: bob@example.com |
* Password
    ```ts
    pk: `email#${string}`
    password: bcrypt(string)
    ```
    | pk                    | sk | attributes             |
    |-----------------------|----|------------------------|
    | email#bob@example.com |    | password: 09u32i1u.... |
* Note
    ```ts
    pk: `email#${string}`
    sk: `note#${cuid}`
    title: string
    body: string
    ```
    | pk                    | sk              | attributes                         |
    |-----------------------|-----------------|------------------------------------|
    | email#bob@example.com | note#iuohk... | title: my first note<br/>body: ... |
    |                       | note#ldjad... | title: my 2nd note<br/>body: ...   |

Access is generally just an easy lookup on `pk = :pk` in the relevant table.


I decided to convert this to a single-table schema because [_reasons_]
(https://www.alexdebrie.com/posts/dynamodb-single-table/#the-solution-pre-join-your-data-into-item-collections)
&mdash; though this app doesn't really benefit from a single-table schema. The
main reason was to dive into the existing models and get a better
understanfing of both the reference stack and `arc.tables` itself.

This turned out to be pretty easy: it's non-production &mdash; no need to
worry about data loss 💀

Also, the schema already includes things like `email#` in its keys, so I
didn't to make too many changes to the queries.

New schema:

* User
    ```ts
    pk: `email#${string}`
    sk: 'email'
    email: string
    ```
* Password
    ```ts
    pk: `email#${string}`
    sk: 'password'
    password: bcrypt(string)
    ```
* Note
    ```ts
    pk: `email#${string}`
    sk: `note#${cuid}`
    title: string
    body: string
    ```

| pk                    | sk            | attributes                         |
|-----------------------|---------------|------------------------------------|
| email#bob@example.com | email         | email: bob@example.com             |
|                       | password      | password: 09u32i1u....             |
|                       | note#iuohk... | title: my first note<br/>body: ... |
|                       | note#ldjad... | title: my 2nd note<br/>body: ...   |

The only real addition was the sort key (`'email' | 'password`) to User and
Password types.

Once these were added, I removed the three different tables and stored all
records in a single table.

I updated the queries to include the sort key (`pk = :pk and sk = :sk`, or for
notes, `pk = :pk and begins_with(sk, :sk)`).
